### PR TITLE
disable hostname verifier check

### DIFF
--- a/src/main/java/com/openx/oauth/client/Helper.java
+++ b/src/main/java/com/openx/oauth/client/Helper.java
@@ -20,6 +20,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
+
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
@@ -34,6 +39,7 @@ import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.conn.ssl.X509HostnameVerifier;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.DefaultHttpClient;
@@ -50,7 +56,7 @@ import com.openx.oauth.redirect.OpenXRedirectStrategy;
  * @author keithmiller
  */
 public class Helper {
-
+    private static final Logger logger = Logger.getLogger(Helper.class.getName());
     protected HttpHost proxy;
     protected String url;
     protected String username;
@@ -338,6 +344,7 @@ public class Helper {
             httpclient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
         }
         if (ignoreSslCertificate) {
+            logger.info("disable ssl certificate check");
             ignoreSslCertificate(httpclient);
         }
         OpenXRedirectStrategy dsr = new OpenXRedirectStrategy();
@@ -355,6 +362,27 @@ public class Helper {
                 @Override
                 public boolean isTrusted(X509Certificate[] chain, String authType) throws CertificateException {
                     return true;
+                }
+            }, new X509HostnameVerifier(){
+
+                @Override
+                public boolean verify(String hostname, SSLSession session) {
+                    return true;
+                }
+
+                @Override
+                public void verify(String host, SSLSocket ssl) throws IOException {
+                    // do nothing
+                }
+
+                @Override
+                public void verify(String host, X509Certificate cert) throws SSLException {
+                    // do nothing
+                }
+
+                @Override
+                public void verify(String host, String[] cns, String[] subjectAlts) throws SSLException {
+                    // do nothing
                 }
             });
             httpclient.getConnectionManager().getSchemeRegistry().register(new Scheme("https", 443, sslsf));


### PR DESCRIPTION
try to fix the following exception:
`javax.net.ssl.SSLPeerUnverifiedException: peer not authenticated
        at sun.security.ssl.SSLSessionImpl.getPeerCertificates(SSLSessionImpl.java:431)
        at org.apache.http.conn.ssl.AbstractVerifier.verify(AbstractVerifier.java:128)
        at org.apache.http.conn.ssl.SSLSocketFactory.connectSocket(SSLSocketFactory.java:390)
        at org.apache.http.impl.conn.DefaultClientConnectionOperator.openConnection(DefaultClientConnectionOperator.java:148)
        at org.apache.http.impl.conn.AbstractPoolEntry.open(AbstractPoolEntry.java:149)
        at org.apache.http.impl.conn.AbstractPooledConnAdapter.open(AbstractPooledConnAdapter.java:121)
        at org.apache.http.impl.client.DefaultRequestDirector.tryConnect(DefaultRequestDirector.java:561)
        at org.apache.http.impl.client.DefaultRequestDirector.execute(DefaultRequestDirector.java:415)
        at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:820)
        at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:754)
        at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:732)
`